### PR TITLE
Fixed Windows support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,11 @@ If you have 256-colors capable terminal you can also specify color in RGB which 
     "Jolacz".color("#FFC482")
     "Jolacz".color("FFC482")
 
-It also has Windows support (uses win32console gem if installed, otherwise strings are returned unaltered).
+For support on Windows, you should install the following gems:
+
+  gem install windows-pr win32console
+
+If the gems aren't installed strings are simply returned unaltered.
 
 Rainbow can be disabled globally by setting:
 

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module Sickill
   module Rainbow
     class << self; attr_accessor :enabled; end
@@ -118,8 +120,11 @@ end
 
 String.send(:include, Sickill::Rainbow)
 
-begin
-  require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
-rescue LoadError
-  Sickill::Rainbow.enabled = false
+# On Windows systems, try to load the local ANSI support library
+if Config::CONFIG['host_os'] =~ /mswin|mingw/
+  begin
+    require 'Win32/Console/ANSI'
+  rescue LoadError
+    Sickill::Rainbow.enabled = false
+  end
 end


### PR DESCRIPTION
After rainbow didn't work on some of my Windows based ruby environments I
started investigating. The major reason for the problem was that some of of the
environments returned mingw32 instead of mswin32 because they are built in a
minimal unix compatibility framework. Apart of that I think depending on the
architecture the Windows system runs upon isn't really necessary most of the
time, so i got rid of the 32 part. Finally, even though it seems JRuby currently
doesn't seem to provide an windows ANSI library, JRuby's RUBY_PLATFORM always
returns 'java'. Therefore the use of Config::CONFIG['host_os'] is highly
recommended to be compatible with a wide range of Ruby implementations.
