### PR TITLE
Adds missing lib/ files to gemspec

### DIFF
--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
    s.summary = %q{Rainbow extends ruby String class enabling coloring text on ANSI terminals}
    s.homepage = %q{http://sickill.net}
    #s.description = "Rainbow is extension to ruby's String class adding support for colorizing text on ANSI terminals. It adds methods like #color, #background, #bright etc."
-   s.files = [ "README.markdown", "Changelog", "LICENSE", "lib/rainbow.rb", "test/rainbow_test.rb" ]
+   s.files = [ "README.markdown", "Changelog", "LICENSE", "lib/rainbow.rb", "lib/ansi_color.rb", "lib/ansi_rgb.rb", "test/rainbow_test.rb" ]
    s.has_rdoc = true
 end
 


### PR DESCRIPTION
I noticed that 1.1.1 is still the latest release version of rainbow, despite newer code in sickill:master that allows it to work without the Config->Rbconfig deprecation notices on Ruby 1.9.3.

When I built the gem from source, I noticed that two required files were missing from the gemspec.

Please release the next version of rainbow when you get a chance, so that I may continue to have beautiful output from my projects, and not deprecation notices :-)
