### PR TITLE
Fix for frozen strings

### DIFF
--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -86,7 +86,7 @@ module Sickill
     def wrap_with_code(code) #:nodoc:
       return self unless Sickill::Rainbow.enabled
 
-      var = self.clone
+      var = self.dup
       matched = var.match(/^(\e\[([\d;]+)m)*/)
       var.insert(matched.end(0), "\e[#{code}m")
       var.concat("\e[0m") unless var =~ /\e\[0m$/

--- a/test/rainbow_test.rb
+++ b/test/rainbow_test.rb
@@ -112,6 +112,12 @@ class RainbowTest < Test::Unit::TestCase #:nodoc:
     assert_equal string, "hello"
   end
 
+  def test_frozen
+    string = "frozen"
+    string.freeze
+    string.color(:red)
+  end
+
   class MyString < String
   end
 


### PR DESCRIPTION
Fixes the problem when adding colors to frozen strings:

```
1.8.7 :006 > x="a"
 => "a" 
1.8.7 :007 > x.color(:yellow)
 => "\e[33ma\e[0m" 
1.8.7 :009 > x.freeze
 => "a" 
1.8.7 :010 > x.color(:yellow)
TypeError: can't modify frozen string
  from /Users/fcoury/.rvm/gems/ree-1.8.7-2011.12/gems/rainbow-1.1.3/lib/rainbow.rb:91:in `insert'
  from /Users/fcoury/.rvm/gems/ree-1.8.7-2011.12/gems/rainbow-1.1.3/lib/rainbow.rb:91:in `wrap_with_code'
  from /Users/fcoury/.rvm/gems/ree-1.8.7-2011.12/gems/rainbow-1.1.3/lib/rainbow.rb:33:in `color'
  from (irb):10
```
