### PR TITLE
Gemfile: Added windows-specific dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem 'coveralls', require: false
 gem 'mime-types', '< 2.0.0', platforms: [:ruby_18]
 gem 'rspec', '3.0.0beta2'
 
+gem 'windows-pr' if RUBY_PLATFORM =~ /win32/i || RUBY_PLATFORM =~ /mingw32/i
+gem 'win32console' if RUBY_PLATFORM =~ /win32/i || RUBY_PLATFORM =~ /mingw32/i
+
 group :development do
   gem 'mutant-rspec'
 end


### PR DESCRIPTION
Since it's not obvious for Windows users why they don't get any coloring, I'm trying to save the next user from having to search the source and the web for the solution.

A lot of other projects use Rainbow, and it's quite a bane for Windows users to find the dependency that breaks the coloring. A silent fail is difficult to debug.

As a last argument, currently Rainbow doesn't work on 1 of the 3 major platforms, with this simple change it will work when people use bundler to install their dependencies. A simple step in the right direction I think.

The change I made has no effect on any platforms other than Windows, and since coloring already works on cygwin, I did not include it.