### PR TITLE
Changing documentation for better output support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ To make your string colored wrap it with `Rainbow()` presenter and call
 ```ruby
 require 'rainbow'
 
-p Rainbow("this is red").red + " and " + Rainbow("this on yellow bg").bg(:yellow) + " and " + Rainbow("even bright underlined!").underline.bright
+puts Rainbow("this is red").red + " and " + Rainbow("this on yellow bg").bg(:yellow) + " and " + Rainbow("even bright underlined!").underline.bright
 
 # => "\e[31mthis is red\e[0m and \e[43mthis on yellow bg\e[0m and \e[4m\e[1meven bright underlined!\e[0m"
 ```


### PR DESCRIPTION
Using the "p" command will not allow colored output in ruby 2.1.2p95 (possibly other versions as well). I spent roughly 30 minutes googling around before I tried using the "puts" command in stead, which worked.