### PR TITLE
use native ANSI color support on Ruby versions >= 2

### DIFF
--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -16,7 +16,7 @@ module Rainbow
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/  && RUBY_VERSION.to_i < 2
     begin
-        require 'Win32/Console/ANSI'
+      require 'Win32/Console/ANSI'
     rescue LoadError
       self.enabled = false
     end

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -11,11 +11,12 @@ module Rainbow
   self.enabled = false if ENV['TERM'] == 'dumb'
   self.enabled = true if ENV['CLICOLOR_FORCE'] == '1'
 
-  # On Windows systems, try to load the local ANSI support library
+  # On Windows systems, try to load the local ANSI support library if Ruby version < 2
+  # Ruby 2.x on Windows includes ANSI support. 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     begin
-      require 'Win32/Console/ANSI'
+        require 'Win32/Console/ANSI' if RUBY_VERSION.to_i < 2
     rescue LoadError
       self.enabled = false
     end

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -14,9 +14,9 @@ module Rainbow
   # On Windows systems, try to load the local ANSI support library if Ruby version < 2
   # Ruby 2.x on Windows includes ANSI support. 
   require 'rbconfig'
-  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/  && RUBY_VERSION.to_i < 2
     begin
-        require 'Win32/Console/ANSI' if RUBY_VERSION.to_i < 2
+        require 'Win32/Console/ANSI'
     rescue LoadError
       self.enabled = false
     end


### PR DESCRIPTION
 Beginning with version 2, Ruby include native ANSI color support on Windows.

win32console gem fails to load on Windows when Ruby version >= 2. This causes rainbow to disable itself.