### PR TITLE
Handle invalid color names

### DIFF
--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -17,8 +17,12 @@ module Rainbow
       when Symbol
         if Named.color_names.include?(color)
           Named.new(ground, color)
-        else X11Named.color_names.include?(color)
+        elsif X11Named.color_names.include?(color)
           X11Named.new(ground, color)
+        else
+          fail ArgumentError,
+            "Unknown color name, valid names: " +
+            (Named.color_names + X11Named.color_names).join(', ')
         end
       when Array
         RGB.new(ground, *color)


### PR DESCRIPTION
I was looking through the code and noticed and `else` that appears to have been intended to be an `elsif`. Both cases will raise an `ArgumentError`, but now the error message will contain all valid color names.