### PR TITLE
mkrf_conf: Improve the check to install win32console

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -155,7 +155,7 @@ instances that are used by formatters with file output.
 
 ## Windows support
 
-For Windows support, you should install the following gems:
+For Windows support on Ruby < 2.0, you should install the following gems:
 
 ```ruby
 gem install windows-pr win32console

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -11,11 +11,10 @@ end
 installer = Gem::DependencyInstaller.new
 
 begin
-  if RUBY_PLATFORM =~ /win32/i || RUBY_PLATFORM =~ /mingw32/i
+  if RUBY_PLATFORM =~ /mswin|cygwin|mingw/ && RUBY_VERSION.to_i < 2
     installer.install('windows-pr')
     installer.install('win32console')
   end
-
 rescue
   exit 1
 end

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -13,8 +13,7 @@ module Rainbow
 
   # On Windows systems, try to load the local ANSI support library if Ruby version < 2
   # Ruby 2.x on Windows includes ANSI support. 
-  require 'rbconfig'
-  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/  && RUBY_VERSION.to_i < 2
+  if RUBY_PLATFORM =~ /mswin|cygwin|mingw/ && RUBY_VERSION.to_i < 2
     begin
       require 'Win32/Console/ANSI'
     rescue LoadError


### PR DESCRIPTION
This is only required for Ruby < 2.0. Also recognize Cygwin as Windows.

Closes #19 for good :-)