### PR TITLE
Add String refinement when using Ruby >= 2.0

### DIFF
--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -1,5 +1,6 @@
 require_relative 'rainbow/global'
 require_relative 'rainbow/legacy'
+require_relative 'rainbow/refinement'
 
 module Rainbow
 
@@ -12,7 +13,7 @@ module Rainbow
   self.enabled = true if ENV['CLICOLOR_FORCE'] == '1'
 
   # On Windows systems, try to load the local ANSI support library if Ruby version < 2
-  # Ruby 2.x on Windows includes ANSI support. 
+  # Ruby 2.x on Windows includes ANSI support.
   if RUBY_PLATFORM =~ /mswin|cygwin|mingw/ && RUBY_VERSION.to_i < 2
     begin
       require 'Win32/Console/ANSI'

--- a/lib/rainbow/refinement.rb
+++ b/lib/rainbow/refinement.rb
@@ -1,0 +1,16 @@
+require_relative 'presenter'
+require_relative 'global'
+
+if RUBY_VERSION >= '2.0'
+
+  module Rainbow
+    refine String do
+      Presenter.instance_methods(false).each do |method_name|
+        define_method(method_name) do |*args|
+          ::Rainbow.global.wrap(self).send(method_name, *args)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/integration/refinement_spec.rb
+++ b/spec/integration/refinement_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'rainbow'
+
+if RUBY_VERSION >= '2.0'
+  class ScopeNotIncluded
+    def self.red_hello
+      'hello'.red
+    end
+  end
+
+  class ScopeIncluded
+    using Rainbow
+    def self.red_hello
+      'hello'.red
+    end
+  end
+
+  describe 'Rainbow refinement' do
+
+    it 'is not active by default' do
+      expect do
+        ScopeNotIncluded.red_hello
+      end.to raise_error(NoMethodError)
+    end
+
+    it 'is available when used' do
+      expect(ScopeIncluded.red_hello).to eq(Rainbow('hello').red)
+    end
+
+    it 'respects disabled state' do
+      Rainbow.enabled = false
+      expect(ScopeIncluded.red_hello).to eq('hello')
+    end
+  end
+end


### PR DESCRIPTION
This is an extraction from code I've had vendored in a project, cleaned up a bit.  Thought it perhaps could get the discussion regarding refinements in #25 kicked up again.

```
>> 'Hello, World!'.blue.bright.underline
NoMethodError: undefined method `blue' for "Hello, World!":String
    (ripl):1:in `<main>'
>> using Rainbow
=> main
>> 'Hello, World!'.blue.bright.underline
=> "\e[34m\e[1m\e[4mHello, World!\e[0m"
```
