### PR TITLE
Fix a warning in ruby 2.4.0dev

### DIFF
--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -12,7 +12,7 @@ module Rainbow
       color = values.size == 1 ? values.first : values
 
       case color
-      when Fixnum
+      when Integer
         Indexed.new(ground, color)
       when Symbol
         if Named.color_names.include?(color)


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005

Fix the following waning.

```
% ruby -v
ruby 2.4.0dev (2016-09-26 trunk 56247) [x86_64-darwin13]
% rake spec
(snip)
/Users/koic/src/github.com/sickill/rainbow/lib/rainbow/color.rb:15:
warning: constant ::Fixnum is deprecated
```

Thanks.
