### PR TITLE
Added bold alias for bright method

### DIFF
--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -44,6 +44,8 @@ module Rainbow
       wrap_with_sgr(TERM_EFFECTS[:bright])
     end
 
+    alias_method :bold, :bright
+
     # Turns on italic style for this text (not well supported by terminal
     # emulators).
     def italic

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -107,7 +107,7 @@ module Rainbow
     end
 
     describe '#bold' do
-      subject { presenter.bright }
+      subject { presenter.bold }
 
       it_behaves_like "rainbow string method"
 

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -106,6 +106,17 @@ module Rainbow
       end
     end
 
+    describe '#bold' do
+      subject { presenter.bright }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 1 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [1])
+      end
+    end
+
     describe '#italic' do
       subject { presenter.italic }
 


### PR DESCRIPTION
Since some other methods like color got aliases like foreground color I thought it would be great to have an alias for **bright** called **bold** since for me the term **bold** was much more clear than the term **bright** and I'm sure that I am not the only one.
