### PR TITLE
FIX #34: NullPresenter handles X11 color name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
   - 2.1.0
   - 2.2.0
   - 2.3.0
-  - rbx
-  - jruby
+  # - rbx
+  - jruby-9
 
 script: "bundle exec rake"
 sudo: false

--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -21,6 +21,14 @@ module Rainbow
     def cyan; self; end
     def white; self; end
 
+    def method_missing(method_name,*args)
+      if Color::X11Named.color_names.include? method_name and args.empty? then
+        self
+      else
+        super
+      end
+    end
+
     alias_method :foreground, :color
     alias_method :fg, :color
     alias_method :bg, :background

--- a/spec/support/presenter_shared_examples.rb
+++ b/spec/support/presenter_shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples_for "presenter with shortcut color methods" do
-  [:black, :red, :green, :yellow, :blue, :magenta, :cyan, :white].each do |name|
+  [:black, :red, :green, :yellow, :blue, :magenta, :cyan, :white, :aqua].each do |name|
     describe "##{name}" do
       subject { presenter.public_send(name) }
 


### PR DESCRIPTION
NullPresenter should have handled X11 color name.
But, previous implementation lacked this.

I implemented NullPresenter X11 color name methods.
Also added a X11 color name to shortcut name shared example.