### PR TITLE
Travis: include 2.4.0 and use exact versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+cache:
+  - bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 bundler_args: --without guard development
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: ruby
 bundler_args: --without guard development
-rvm:
-  - 2.0.0
-  - 2.1.9
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  # - rbx
-  - jruby-9.1.6.0
+
 matrix:
   include:
     - rvm: 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
+language: ruby
 bundler_args: --without guard development
 rvm:
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.1.9
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   # - rbx
-  - jruby-9
-
-script: "bundle exec rake"
-sudo: false
+  - jruby-9.1.6.0
+matrix:
+  include:
+    - rvm: 2.0.0
+    - rvm: 2.1.9
+    - rvm: 2.2.6
+    - rvm: 2.3.3
+    - rvm: 2.4.0
+    - rvm: jruby-9.1.6.0
+      jdk: oraclejdk8
+      env:
+        - JRUBY_OPTS=--debug

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem 'rake'
 gem 'coveralls', require: false
 gem 'mime-types', '< 2.0.0', platforms: [:ruby_18]
-gem 'rspec', '3.0.0beta2'
+gem 'rspec'
 
 group :development do
   gem 'mutant-rspec'


### PR DESCRIPTION
This PR changes the Travis build matrix a little, so that it's possible to add build-specific ENV vars and settings.

 - It adds Bundler's folder to cache
 - It uses the default `bundle exec rake` for a build task
  - The versions come ruby-install of today
  - added --debug to JRuby to improve accuracy of code coverage calculation

This indicates that 2.4.0 **already** builds and runs tests **without any output like this**:

```
rainbow-2.1.0/lib/rainbow/color.rb:15: warning: constant ::Fixnum is deprecated
```