### PR TITLE
Rakefile: Bundler, RSpec optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,18 @@
-require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
+begin
+  require "bundler/gem_tasks"
+rescue LoadError
+  # No bundler, does not install gem_tasks
+end
 
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # No RSpec, does not install rake_task
+  # Add blank replacement task
+  task :spec do
+    # No-op
+  end
+end
 
-task :default => :spec
+task default: :spec


### PR DESCRIPTION
See #40

This PR changes the Rakefile to make Bundler and RSpec optional. When no RSpec is available, the `spec` task is defined a "no-op" with no output.

Here's an example, mentioning the role of Makefile/Rakefile re: "ext": https://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_use_a_Rakefile_instead_of_a_Makefile Thanks to everyone in #40 for being helpful and sharing their findings.

Does this help you folks with the issue?