### PR TITLE
Ext: add a blank rakefile when it works

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -18,3 +18,5 @@ begin
 rescue
   exit 1
 end
+
+File.write(File.join(File.dirname(__FILE__), 'Rakefile'), "task :default\n")


### PR DESCRIPTION
This PR adds a blank Rakefile to the ext folder when building, so that rake hits that instead of the main Rakefile.

See #42, #40.