### PR TITLE
Add Rake as an explicit dependency

### DIFF
--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "rake", ">= 12"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.extensions    = ["ext/mkrf_conf.rb"]
 end


### PR DESCRIPTION
In order to have the `rake` program when the post-install steps are taken, this PR adds Rake as a gem dependency.

  - See #44