### PR TITLE
Fix `Color.build` ignoring Integers in older Ruby versions

### DIFF
--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -12,7 +12,12 @@ module Rainbow
       color = values.size == 1 ? values.first : values
 
       case color
-      when Integer
+      # NOTE: Properly handle versions before/after Ruby 2.4.0.
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      # However previous versions would still use Fixnum.
+      # To avoid missing `Fixnum` input, call `0.class` which would
+      # return either `Integer` or `Fixnum`.
+      when 0.class
         Indexed.new(ground, color)
       when Symbol
         if Named.color_names.include?(color)


### PR DESCRIPTION
Follow-up of 2dba7b2f42768ea80a19435a504939072ed935e3
Pre-2.4.0: Integer == Fixnum => false
2.4.0: Integer == Fixnum => true


@koic @sickill 