### PR TITLE
Add faint/dark method and fix missing bold alias in NullPresenter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,8 @@ Rainbow presenter adds the following methods to presented string:
 * `blink`
 * `inverse`
 * `hide`
-* `italic` (not well supported by terminal emulators).
+* `faint` (not well supported by terminal emulators)
+* `italic` (not well supported by terminal emulators)
 
 Text color can also be changed by calling a method named by a color:
 

--- a/lib/rainbow/ext/string.rb
+++ b/lib/rainbow/ext/string.rb
@@ -24,6 +24,10 @@ module Rainbow
           Rainbow(self).bright
         end
 
+        def faint
+          Rainbow(self).faint
+        end
+
         def italic
           Rainbow(self).italic
         end

--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -32,6 +32,7 @@ module Rainbow
     alias_method :foreground, :color
     alias_method :fg, :color
     alias_method :bg, :background
+    alias_method :bold, :bright
 
   end
 

--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -6,6 +6,7 @@ module Rainbow
     def background(*values); self; end
     def reset; self; end
     def bright; self; end
+    def faint; self; end
     def italic; self; end
     def underline; self; end
     def blink; self; end
@@ -33,6 +34,7 @@ module Rainbow
     alias_method :fg, :color
     alias_method :bg, :background
     alias_method :bold, :bright
+    alias_method :dark, :faint
 
   end
 

--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -9,6 +9,7 @@ module Rainbow
     TERM_EFFECTS = {
       reset:     0,
       bright:    1,
+      faint:     2,
       italic:    3,
       underline: 4,
       blink:     5,
@@ -45,6 +46,14 @@ module Rainbow
     end
 
     alias_method :bold, :bright
+
+    # Turns on faint/dark for this text (not well supported by terminal
+    # emulators).
+    def faint
+      wrap_with_sgr(TERM_EFFECTS[:faint])
+    end
+
+    alias_method :dark, :faint
 
     # Turns on italic style for this text (not well supported by terminal
     # emulators).

--- a/spec/integration/rainbow_spec.rb
+++ b/spec/integration/rainbow_spec.rb
@@ -77,6 +77,11 @@ describe 'Rainbow() wrapper' do
     expect(result).to eq("\e[1mhello\e[0m")
   end
 
+  it 'allows making text faint' do
+    result = Rainbow('hello').faint
+    expect(result).to eq("\e[2mhello\e[0m")
+  end
+
   it 'allows making text italic' do
     result = Rainbow('hello').italic
     expect(result).to eq("\e[3mhello\e[0m")
@@ -112,6 +117,8 @@ describe 'Rainbow() wrapper' do
       foreground(:red).
       bright.
       bold.
+      faint.
+      dark.
       italic.
       background('#ff8040').
       underline.
@@ -121,7 +128,7 @@ describe 'Rainbow() wrapper' do
       hide
 
     expect(result).to eq(
-      "\e[31m\e[1m\e[1m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8mhello\e[0m"
+      "\e[31m\e[1m\e[1m\e[2m\e[2m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8mhello\e[0m"
     )
   end
 
@@ -136,6 +143,8 @@ describe 'Rainbow() wrapper' do
         foreground(:red).
         bright.
         bold.
+        faint.
+        dark.
         italic.
         background('#ff8040').
         underline.

--- a/spec/integration/rainbow_spec.rb
+++ b/spec/integration/rainbow_spec.rb
@@ -111,6 +111,7 @@ describe 'Rainbow() wrapper' do
     result = Rainbow('hello').
       foreground(:red).
       bright.
+      bold.
       italic.
       background('#ff8040').
       underline.
@@ -120,7 +121,7 @@ describe 'Rainbow() wrapper' do
       hide
 
     expect(result).to eq(
-      "\e[31m\e[1m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8mhello\e[0m"
+      "\e[31m\e[1m\e[1m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8mhello\e[0m"
     )
   end
 
@@ -134,6 +135,7 @@ describe 'Rainbow() wrapper' do
       result = Rainbow('hello').
         foreground(:red).
         bright.
+        bold.
         italic.
         background('#ff8040').
         underline.

--- a/spec/integration/string_spec.rb
+++ b/spec/integration/string_spec.rb
@@ -31,6 +31,10 @@ describe 'String mixin' do
     expect('hello'.bright).to eq(Rainbow('hello').bright)
   end
 
+  it 'proxies faint to Rainbow().faint' do
+    expect('hello'.faint).to eq(Rainbow('hello').faint)
+  end
+
   it 'proxies italic to Rainbow().italic' do
     expect('hello'.italic).to eq(Rainbow('hello').italic)
   end

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -58,6 +58,12 @@ module Rainbow
       it_behaves_like "rainbow null string method"
     end
 
+    describe '#bold' do
+      subject { presenter.bold }
+
+      it_behaves_like "rainbow null string method"
+    end
+
     describe '#italic' do
       subject { presenter.italic }
 

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -64,6 +64,18 @@ module Rainbow
       it_behaves_like "rainbow null string method"
     end
 
+    describe '#faint' do
+      subject { presenter.faint }
+
+      it_behaves_like "rainbow null string method"
+    end
+
+    describe '#dark' do
+      subject { presenter.dark }
+
+      it_behaves_like "rainbow null string method"
+    end
+
     describe '#italic' do
       subject { presenter.italic }
 

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -117,6 +117,28 @@ module Rainbow
       end
     end
 
+    describe '#faint' do
+      subject { presenter.faint }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 2 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [2])
+      end
+    end
+
+    describe '#dark' do
+      subject { presenter.dark }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 2 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [2])
+      end
+    end
+
     describe '#italic' do
       subject { presenter.italic }
 


### PR DESCRIPTION
I confirmed faint/dark can be used in Terminal.app and iTerm 2 (3.0) in OS X Sierra.
This PR enables to use it..!

Also, fixed bug that calling `bold` when rainbow is not enabled causes no method error.