### PR TITLE
Add open-ended rake dependency

### DIFF
--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rake"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.extensions    = ["ext/mkrf_conf.rb"]
 end


### PR DESCRIPTION
In order to address [#57] I have added an open-ended Rake dependency to this gem. Currently when building in environments such as Ubuntu or Alpine linux with applications such as Sinatra (that do not require rake) any gem including Rainbow will cause bundler to fail.

We may want to look at what version of Rake you *really* require. But in the meantime, a dependency on Rake should be added to the gemspec ASAP