### PR TITLE
Travis: RVM note, extract env, cache bundler right; Appveyor: fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.2.7
     - rvm: 2.3.4
     - rvm: 2.4.1
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       jdk: oraclejdk8
     - rvm: 2.2.7
       install: true # This skips 'bundle install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 cache:
-  - bundler
+  bundler: true
+
 before_install:
-  - gem update --system
   - gem install bundler
+
 bundler_args: --without guard development
 
 matrix:
@@ -14,8 +15,10 @@ matrix:
     - rvm: 2.4.1
     - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
-      env:
-        - JRUBY_OPTS=--debug
     - rvm: 2.2.7
       install: true # This skips 'bundle install'
       script: gem build rainbow && gem install *.gem
+
+env:
+  global:
+    - JRUBY_OPTS=--debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,27 +3,34 @@
 version: "{build}"
 
 install:
-  - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem update --system --no-document
-  - gem install bundler --no-document
-  - bundle install --jobs 3 --retry 3 --without guard development
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install --jobs 3 --retry 3 --without guard development 
 
 build: off
 
+cache:
+  - vendor/bundle
+
 init:
   - git config --global core.autocrlf true
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
 
 test_script:
   - bundle exec rake
 
 environment:
   matrix:
-    - ruby_version: '21'
-    - ruby_version: 21-x64
-    - ruby_version: '22'
-    - ruby_version: 22-x64
-    - ruby_version: '23'
-    - ruby_version: 23-x64
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 21-x64
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 22-x64
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 23-x64
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This tiny change fixes ~three~ five things:

## Travis

  - speed: RVM does `gem update --system` on its own
  - readability: configure `JRUBY_OPTS` as env global
  - clarity: Travis YAML config `cache` shorthand for `bundler` corrected
  - update: use latest JRuby in CI matrix - `jruby-9.1.14.0` 

## Appveyor

  - Build fix: used https://www.appveyor.com/docs/lang/ruby/ as a template and harmonized our configuration to that, and the tests began passing.