### PR TITLE
RSpec: disable monkey patching

### DIFF
--- a/spec/integration/instance_spec.rb
+++ b/spec/integration/instance_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rainbow'
 
-describe 'Custom Rainbow instance' do
+RSpec.describe 'Custom Rainbow instance' do
   it 'inherits enabled state from the global instance' do
     Rainbow.enabled = :yep
     expect(Rainbow.new.enabled).to eq(:yep)

--- a/spec/integration/rainbow_spec.rb
+++ b/spec/integration/rainbow_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rainbow'
 
-describe 'Rainbow() wrapper' do
+RSpec.describe 'Rainbow() wrapper' do
   before do
     Rainbow.enabled = true
   end

--- a/spec/integration/string_spec.rb
+++ b/spec/integration/string_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rainbow/ext/string'
 
-describe 'String mixin' do
+RSpec.describe 'String mixin' do
   before do
     Rainbow.enabled = true
   end

--- a/spec/integration/uncolor_spec.rb
+++ b/spec/integration/uncolor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rainbow'
 
-describe 'uncolor method' do
+RSpec.describe 'uncolor method' do
 
   it 'strips ansi color escape code' do
     expect(Rainbow.uncolor("\e[35mhello\e[0mm")).to eq 'hellom'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,7 @@ if ENV["CI"] && (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby")
 end
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |file| require file }
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end

--- a/spec/support/presenter_shared_examples.rb
+++ b/spec/support/presenter_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for "presenter with shortcut color methods" do
+RSpec.shared_examples_for "presenter with shortcut color methods" do
   %i[black red green yellow blue magenta cyan white aqua].each do |name|
     describe "##{name}" do
       subject { presenter.public_send(name) }

--- a/spec/unit/color_spec.rb
+++ b/spec/unit/color_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rainbow/color'
 
 module Rainbow
-  describe Color do
+  RSpec.describe Color do
     describe '.build' do
       subject { described_class.build(ground, values) }
 
@@ -77,7 +77,7 @@ module Rainbow
     end
   end
 
-  describe Color::Indexed do
+  RSpec.describe Color::Indexed do
     let(:color) { described_class.new(ground, 5) }
 
     describe '#codes' do
@@ -97,7 +97,7 @@ module Rainbow
     end
   end
 
-  describe Color::Named do
+  RSpec.describe Color::Named do
     let(:color) { described_class.new(ground, name) }
 
     describe '#codes' do
@@ -225,7 +225,7 @@ module Rainbow
     end
   end
 
-  describe Color::RGB do
+  RSpec.describe Color::RGB do
     let(:color) { described_class.new(ground, r, g, b) }
 
     describe '#codes' do
@@ -266,7 +266,7 @@ module Rainbow
     end
   end
 
-  describe Color::X11Named do
+  RSpec.describe Color::X11Named do
     let(:color) { described_class.new(ground, name) }
 
     describe '#codes' do

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rainbow'
 
-describe Sickill::Rainbow do
+RSpec.describe Sickill::Rainbow do
   describe '.enabled' do
     before do
       ::Rainbow.enabled = :nope

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rainbow/null_presenter'
 
 module Rainbow
-  describe NullPresenter do
+  RSpec.describe NullPresenter do
     let(:presenter) { described_class.new('hello') }
 
     shared_examples_for "rainbow null string method" do

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rainbow/presenter'
 
 module Rainbow
-  describe Presenter do
+  RSpec.describe Presenter do
     let(:presenter) { described_class.new('hello') }
 
     shared_examples_for "rainbow string method" do

--- a/spec/unit/string_utils_spec.rb
+++ b/spec/unit/string_utils_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rainbow/string_utils'
 
 module Rainbow
-  describe StringUtils do
+  RSpec.describe StringUtils do
     describe '.wrap_with_sgr' do
       subject { described_class.wrap_with_sgr(string, codes) }
 

--- a/spec/unit/wrapper_spec.rb
+++ b/spec/unit/wrapper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rainbow/wrapper'
 
 module Rainbow
-  describe Wrapper do
+  RSpec.describe Wrapper do
     let(:wrapper) { described_class.new(enabled) }
 
     it "is enabled by default" do


### PR DESCRIPTION
This PR configures RSpec to use its [**zero-monkey-patching mode**](https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration/zero-monkey-patching-mode).

The code changes are to use `RSpec.describe` and `RSpec.shared_examples_for`.