### PR TITLE
Add hexadecimal RGB triplet string format check

### DIFF
--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -38,7 +38,7 @@ module Rainbow
     def self.parse_hex_color(hex)
       unless hex =~ /^#?[a-f0-9]{6}/i
         raise ArgumentError,
-          "Invalid hexadecimal RGB triplet. Valid format: /^#?[a-f0-9]{6}/i"
+              "Invalid hexadecimal RGB triplet. Valid format: /^#?[a-f0-9]{6}/i"
       end
 
       hex = hex.sub(/^#/, '')

--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -36,6 +36,11 @@ module Rainbow
     end
 
     def self.parse_hex_color(hex)
+      unless hex =~ /^#?[a-f0-9]{6}/i
+        raise ArgumentError,
+          "Invalid hexadecimal RGB triplet. Valid format: /^#?[a-f0-9]{6}/i"
+      end
+
       hex = hex.sub(/^#/, '')
       r   = hex[0..1].to_i(16)
       g   = hex[2..3].to_i(16)

--- a/spec/unit/color_spec.rb
+++ b/spec/unit/color_spec.rb
@@ -37,7 +37,7 @@ module Rainbow
         specify { expect(subject.b).to eq(112) }
       end
 
-      context "when single string given" do
+      context "when single hexadecimal string given" do
         let(:values) { ['#deadcc'] }
 
         it { should be_instance_of(Color::RGB) }
@@ -46,6 +46,14 @@ module Rainbow
         specify { expect(subject.r).to eq(222) }
         specify { expect(subject.g).to eq(173) }
         specify { expect(subject.b).to eq(204) }
+      end
+
+      context "when single non hexadecimal string given" do
+        let(:values) { ['green'] }
+
+        it 'raises ArgumentError' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
       end
 
       context "when 2 elements" do


### PR DESCRIPTION
This PR adds a format check when the user inputs a string, addressing the issue #82.

Please note that I'm still not sure enforcing an `ArgumentError` is the best solution because some people could be using a non valid hexadecimal string in their project without any visible impact (i.e `'green'`) and that change could potentially break their code.