### PR TITLE
introducing #cross_out

### DIFF
--- a/lib/rainbow/ext/string.rb
+++ b/lib/rainbow/ext/string.rb
@@ -46,6 +46,12 @@ module Rainbow
         def hide
           Rainbow(self).hide
         end
+
+        def cross_out
+          Rainbow(self).cross_out
+        end
+
+        alias strike cross_out
       end
     end
   end

--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -40,6 +40,10 @@ module Rainbow
       self
     end
 
+    def cross_out
+      self
+    end
+
     def black
       self
     end
@@ -89,5 +93,6 @@ module Rainbow
     alias bg background
     alias bold bright
     alias dark faint
+    alias strike cross_out
   end
 end

--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -12,7 +12,8 @@ module Rainbow
       underline: 4,
       blink:     5,
       inverse:   7,
-      hide:      8
+      hide:      8,
+      cross_out: 9
     }.freeze
 
     # Sets color of this text.
@@ -79,6 +80,12 @@ module Rainbow
     def hide
       wrap_with_sgr(TERM_EFFECTS[:hide])
     end
+
+    def cross_out
+      wrap_with_sgr(TERM_EFFECTS[:cross_out])
+    end
+
+    alias strike cross_out
 
     def black
       color(:black)

--- a/spec/integration/rainbow_spec.rb
+++ b/spec/integration/rainbow_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe 'Rainbow() wrapper' do
     expect(result).to eq("\e[8mhello\e[0m")
   end
 
+  it 'allows making text crossed out' do
+    result = Rainbow('hello').cross_out
+    expect(result).to eq("\e[9mhello\e[0m")
+  end
+
+  it 'allows making text stricken' do
+    result = Rainbow('hello').strike
+    expect(result).to eq("\e[9mhello\e[0m")
+  end
+
   it 'allows resetting all the attributes' do
     result = Rainbow('hello').reset
     expect(result).to eq("\e[0mhello\e[0m")
@@ -125,9 +135,11 @@ RSpec.describe 'Rainbow() wrapper' do
              .blink
              .inverse
              .hide
+             .cross_out
+             .strike
 
     expect(result).to eq(
-      "\e[31m\e[1m\e[1m\e[2m\e[2m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8mhello\e[0m"
+      "\e[31m\e[1m\e[1m\e[2m\e[2m\e[3m\e[48;5;215m\e[4m\e[34m\e[5m\e[7m\e[8m\e[9m\e[9mhello\e[0m"
     )
   end
 
@@ -150,6 +162,7 @@ RSpec.describe 'Rainbow() wrapper' do
                .blink
                .inverse
                .hide
+               .cross_out
 
       expect(result).to eq('hello')
     end

--- a/spec/integration/string_spec.rb
+++ b/spec/integration/string_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe 'String mixin' do
     expect('hello'.reset).to eq(Rainbow('hello').reset)
   end
 
+  it 'proxies cross_out to Rainbow().cross_out' do
+    expect('hello'.cross_out).to eq(Rainbow('hello').cross_out)
+  end
+
+  it 'proxies strike to Rainbow().strike_out' do
+    expect('hello'.strike).to eq(Rainbow('hello').strike)
+  end
+
   context "when Rainbow is disabled" do
     before do
       Rainbow.enabled = false
@@ -74,6 +82,8 @@ RSpec.describe 'String mixin' do
                .blink
                .inverse
                .hide
+               .cross_out
+               .strike
 
       expect(result).to eq('hello')
     end

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -105,6 +105,18 @@ module Rainbow
       it_behaves_like "rainbow null string method"
     end
 
+    describe "#cross_out" do
+      subject { presenter.cross_out }
+
+      it_behaves_like "rainbow null string method"
+    end
+
+    describe "#strike" do
+      subject { presenter.strike }
+
+      it_behaves_like "rainbow null string method"
+    end
+
     it_behaves_like "presenter with shortcut color methods"
   end
 end

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -194,6 +194,28 @@ module Rainbow
       end
     end
 
+    describe '#cross_out' do
+      subject { presenter.cross_out }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 9 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [9])
+      end
+    end
+
+    describe '#strike' do
+      subject { presenter.strike }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 9 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [9])
+      end
+    end
+
     it_behaves_like "presenter with shortcut color methods"
   end
 end

--- a/spec/unit/string_utils_spec.rb
+++ b/spec/unit/string_utils_spec.rb
@@ -74,7 +74,9 @@ module Rainbow
             color(:blue).
             blink.
             inverse.
-            hide
+            hide.
+            cross_out.
+            strike
         end
 
         it "removes ansi color codes" do


### PR DESCRIPTION
This PR adds `#cross_out` and its alias `#strike` for both presenters and Strings.