### PR TITLE
Simplify `wrap_with_sgr` method

### DIFF
--- a/lib/rainbow/string_utils.rb
+++ b/lib/rainbow/string_utils.rb
@@ -4,13 +4,12 @@ module Rainbow
       return string if codes.empty?
 
       seq = "\e[" + codes.join(";") + "m"
-      match = string.match(/^(\e\[([\d;]+)m)*/)
-      seq_pos = match.end(0)
-      string = string[0...seq_pos] + seq + string[seq_pos..-1]
 
-      string += "\e[0m" unless string =~ /\e\[0m$/
+      string = string.sub(/^(\e\[([\d;]+)m)*/) { |m| m + seq }
 
-      string
+      return string if string.end_with? "\e[0m"
+
+      string + "\e[0m"
     end
 
     def self.uncolor(string)


### PR DESCRIPTION
I am currently looking into optimizing rainbow colorization a bit. For any large numbers of elements, which need to be colored the time spend in parsing colors and wrapping the strings in escape sequences is significant according to my profiling.

This is just a small change which already is a small improvement in the right direction without needing to change the API.

On my machine, using benchmark.bmbm for 100,000 iterations:
```
Rehearsal -----------------------------------------
orig    0.494690   0.000626   0.495316 (  0.496591)
new     0.392162   0.000046   0.392208 (  0.393326)
-------------------------------- total: 1.253264sec

            user     system      total        real
orig    0.509721   0.000010   0.509731 (  0.510783)
new     0.362617   0.000005   0.362622 (  0.363267)
```