### PR TITLE
CI: Allow Bundler 2, add Rubies to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,19 @@ language: ruby
 cache:
   bundler: true
 
-before_install:
-  - gem install bundler
-
 bundler_args: --without guard development
 
 matrix:
   include:
     - rvm: 2.1.10
-    - rvm: 2.2.9
-    - rvm: 2.3.6
-    - rvm: 2.4.3
-    - rvm: 2.5.0
-    - rvm: jruby-9.1.14.0
+    - rvm: 2.2.10
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6.1
+    - rvm: jruby-9.1.17.0 # ruby 2.3
       jdk: oraclejdk8
-    - rvm: 2.2.9
+    - rvm: 2.2.10
       install: true # This skips 'bundle install'
       script: gem build rainbow && gem install *.gem
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'bundler'
 gem 'rake'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'bundler'
 gem 'rake'
 
 group :test do

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -17,6 +17,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.3"
 end

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.add_development_dependency "bundler", [">= 1.3", "< 3"]
 end


### PR DESCRIPTION
This PR adds more Rubies to the build matrix and allows use of Bundler 1 or 2.