### PR TITLE
Use rubocop latest, drop support for Ruby 2.1, 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - "spec/**/*"
     - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  TargetRubyVersion: 2.2
   Exclude:
     - "spec/**/*"
     - "vendor/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ bundler_args: --without guard development
 
 matrix:
   include:
-    - rvm: 2.2.10
     - rvm: 2.3.8
     - rvm: 2.4.5
     - rvm: 2.5.3
@@ -15,7 +14,7 @@ matrix:
       jdk: oraclejdk8
     - rvm: jruby-9.2.6.0 # ruby 2.5
       jdk: oraclejdk8
-    - rvm: 2.2.10
+    - rvm: 2.3.8
       install: true # This skips 'bundle install'
       script: gem build rainbow && gem install *.gem
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ bundler_args: --without guard development
 
 matrix:
   include:
-    - rvm: 2.1.10
     - rvm: 2.2.10
     - rvm: 2.3.8
     - rvm: 2.4.5
     - rvm: 2.5.3
     - rvm: 2.6.1
     - rvm: jruby-9.1.17.0 # ruby 2.3
+      jdk: oraclejdk8
+    - rvm: jruby-9.2.6.0 # ruby 2.5
       jdk: oraclejdk8
     - rvm: 2.2.10
       install: true # This skips 'bundle install'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
 end
 
 group :test, :development do
-  gem 'rubocop', '~> 0.51.0'
+  gem 'rubocop', require: false
 end
 
 group :guard do

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 require 'rspec/core/rake_task'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ version: "{build}"
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - bundle config --local path vendor/bundle
-  - bundle install --jobs 3 --retry 3 --without guard development 
+  - bundle install --jobs 3 --retry 3 --without guard development
 
 build: off
 
@@ -25,12 +25,16 @@ test_script:
 
 environment:
   matrix:
-    - RUBY_VERSION: 21
-    - RUBY_VERSION: 21-x64
     - RUBY_VERSION: 22
     - RUBY_VERSION: 22-x64
     - RUBY_VERSION: 23
     - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24
+    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 25
+    - RUBY_VERSION: 25-x64
+    - RUBY_VERSION: 26
+    - RUBY_VERSION: 26-x64
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,6 @@ environment:
     - RUBY_VERSION: 24-x64
     - RUBY_VERSION: 25
     - RUBY_VERSION: 25-x64
-    - RUBY_VERSION: 26
-    - RUBY_VERSION: 26-x64
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,6 @@ test_script:
 
 environment:
   matrix:
-    - RUBY_VERSION: 22
-    - RUBY_VERSION: 22-x64
     - RUBY_VERSION: 23
     - RUBY_VERSION: 23-x64
     - RUBY_VERSION: 24

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rainbow/global'
 
 module Rainbow

--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rainbow
   class Color
     attr_reader :ground
@@ -103,7 +105,7 @@ module Rainbow
       end
 
       def initialize(ground, *values)
-        if values.min < 0 || values.max > 255
+        if values.min.negative? || values.max > 255
           raise ArgumentError, "RGB value outside 0-255 range"
         end
 

--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -66,14 +66,14 @@ module Rainbow
 
     class Named < Indexed
       NAMES = {
-        black:   0,
-        red:     1,
-        green:   2,
-        yellow:  3,
-        blue:    4,
+        black: 0,
+        red: 1,
+        green: 2,
+        yellow: 3,
+        blue: 4,
         magenta: 5,
-        cyan:    6,
-        white:   7,
+        cyan: 6,
+        white: 7,
         default: 9
       }.freeze
 

--- a/lib/rainbow/ext/string.rb
+++ b/lib/rainbow/ext/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rainbow'
 
 module Rainbow

--- a/lib/rainbow/global.rb
+++ b/lib/rainbow/global.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'wrapper'
 
 module Rainbow

--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rainbow
   class NullPresenter < ::String
     def color(*_values)

--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -5,14 +5,14 @@ require_relative 'color'
 module Rainbow
   class Presenter < ::String
     TERM_EFFECTS = {
-      reset:     0,
-      bright:    1,
-      faint:     2,
-      italic:    3,
+      reset: 0,
+      bright: 1,
+      faint: 2,
+      italic: 3,
       underline: 4,
-      blink:     5,
-      inverse:   7,
-      hide:      8,
+      blink: 5,
+      inverse: 7,
+      hide: 8,
       cross_out: 9
     }.freeze
 

--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'string_utils'
 require_relative 'x11_color_names'
 require_relative 'color'

--- a/lib/rainbow/refinement.rb
+++ b/lib/rainbow/refinement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'presenter'
 require_relative 'global'
 

--- a/lib/rainbow/string_utils.rb
+++ b/lib/rainbow/string_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rainbow
   class StringUtils
     def self.wrap_with_sgr(string, codes)

--- a/lib/rainbow/version.rb
+++ b/lib/rainbow/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rainbow
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.0"
 end

--- a/lib/rainbow/wrapper.rb
+++ b/lib/rainbow/wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'presenter'
 require_relative 'null_presenter'
 

--- a/lib/rainbow/x11_color_names.rb
+++ b/lib/rainbow/x11_color_names.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rainbow
   module X11ColorNames
     NAMES = {

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rainbow/version'
 
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary               = 'Colorize printed text on ANSI terminals'
   spec.homepage              = "https://github.com/sickill/rainbow"
   spec.license               = "MIT"
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rainbow/version'
@@ -11,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary               = 'Colorize printed text on ANSI terminals'
   spec.homepage              = "https://github.com/sickill/rainbow"
   spec.license               = "MIT"
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -118,5 +118,13 @@ module Rainbow
     end
 
     it_behaves_like "presenter with shortcut color methods"
+
+    describe "#method_missing" do
+      it "fails regularly when not caught" do
+        expect {
+          presenter.trololol
+        }.to raise_error(NoMethodError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR updates the Gemfile use any (aka latest release of) RuboCop.

- Gemspec: _Update_ the lowest-allowed Ruby to ~2.2+~ **2.3**
- RuboCop config: Explicitly set the chosen Ruby requirement
- CI: Drop Ruby 2.1, 2.2 - See #90 
- CI: Add JRuby 9.2.6.0 (latest GA release)

Then **lint** to the new rules.