### PR TITLE
CI: Prune 2.3 (and 2.3-alike jruby version)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - "spec/**/*"
     - "vendor/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,12 @@ bundler_args: --without guard development
 
 matrix:
   include:
-    - rvm: 2.3.8
-    - rvm: 2.4.5
-    - rvm: 2.5.3
-    - rvm: 2.6.1
-    - rvm: jruby-9.1.17.0 # ruby 2.3
-      jdk: oraclejdk8
+    - rvm: 2.4.6
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: jruby-9.2.6.0 # ruby 2.5
       jdk: oraclejdk8
-    - rvm: 2.3.8
+    - rvm: 2.4.6
       install: true # This skips 'bundle install'
       script: gem build rainbow && gem install *.gem
 

--- a/lib/rainbow/color.rb
+++ b/lib/rainbow/color.rb
@@ -38,7 +38,7 @@ module Rainbow
     end
 
     def self.parse_hex_color(hex)
-      unless hex =~ /^#?[a-f0-9]{6}/i
+      unless /^#?[a-f0-9]{6}/i.match?(hex)
         raise ArgumentError,
               "Invalid hexadecimal RGB triplet. Valid format: /^#?[a-f0-9]{6}/i"
       end

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary               = 'Colorize printed text on ANSI terminals'
   spec.homepage              = "https://github.com/sickill/rainbow"
   spec.license               = "MIT"
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
This PR drop 2.3 from the CI matrix.

https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/