### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.3, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ bundler_args: --without guard development
 matrix:
   include:
     - rvm: 2.3.8
-    - rvm: 2.4.5
-    - rvm: 2.5.3
-    - rvm: 2.6.1
+    - rvm: 2.4.6
+    - rvm: 2.5.5
+    - rvm: 2.6.3
     - rvm: jruby-9.1.17.0 # ruby 2.3
       jdk: oraclejdk8
-    - rvm: jruby-9.2.6.0 # ruby 2.5
+    - rvm: jruby-9.2.7.0 # ruby 2.5
       jdk: oraclejdk8
     - rvm: 2.3.8
       install: true # This skips 'bundle install'


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known