### PR TITLE
Use `git ls-files -z` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,14 +7,14 @@ AllCops:
   Exclude:
     - "spec/**/*"
     - "vendor/**/*"
-Documentation:
+Style/Documentation:
   Enabled: false
 
-HashSyntax:
+Style/HashSyntax:
   Enabled: false
 
-MethodName:
+Naming/MethodName:
   Enabled: false
 
-StringLiterals:
+Style/StringLiterals:
   Enabled: false

--- a/lib/rainbow/ext/string.rb
+++ b/lib/rainbow/ext/string.rb
@@ -59,4 +59,6 @@ module Rainbow
   end
 end
 
-::String.send(:include, Rainbow::Ext::String::InstanceMethods)
+class String
+  include Rainbow::Ext::String::InstanceMethods
+end

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license               = "MIT"
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Currently, the gemspec has a warning about `$INPUT_RECORD_SEPARATOR`.

```bash
$ bundle exec ruby -w -rrainbow -e 
/home/pocke/ghq/github.com/sickill/rainbow/rainbow.gemspec:18: warning: global variable `$INPUT_RECORD_SEPARATOR' not initialized
```



This pull request suppresses the warning.
I think using `-z` option and `split("\x0")` is better than the current.
`bundle gem`'s boilerplate also has the style.

---


RuboCop's new cop added an offense. And I got warnings about .rubocop.yml.
So this pull request also suppresses the warning.