### PR TITLE
(chore) Add v0.80 RuboCop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,12 @@ Naming/MethodName:
 
 Style/StringLiterals:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
This PR deals with this RuboCop output: **enabling these new cops**.

```
Running RuboCop...

The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:

 - Style/HashEachMethods (0.80)

 - Style/HashTransformKeys (0.80)

 - Style/HashTransformValues (0.80)

For more information: https://docs.rubocop.org/en/latest/versioning/

Inspecting 15 files

...............
```