### PR TITLE
chore: Pin RuboCop to old version, which supports Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development do
 end
 
 group :test, :development do
-  gem 'rubocop', require: false
+  gem 'rubocop', '0.81.0', require: false # This version supports Ruby 2.3
 end
 
 group :guard do


### PR DESCRIPTION
In order to get a green build, this PR pins the RuboCop version to the last supported version which runs on Ruby 2.3.

