### PR TITLE
Require Ruby 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - "spec/**/*"
     - "vendor/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ bundler_args: --without guard development
 
 matrix:
   include:
-    - rvm: 2.3
     - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6
@@ -16,7 +15,7 @@ matrix:
     - rvm: jruby-9.2.11.0 # ruby 2.5
       jdk: oraclejdk9
     - rvm: truffleruby-head
-    - rvm: 2.3
+    - rvm: 2.4
       install: true # This skips 'bundle install'
       script: gem build rainbow && gem install *.gem
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,6 @@ environment:
     - RUBY_VERSION: 25-x64
     - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 23-x64
 
 matrix:
   fast_finish: true

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary               = 'Colorize printed text on ANSI terminals'
   spec.homepage              = "https://github.com/sickill/rainbow"
   spec.license               = "MIT"
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.files = Dir['lib/**/*'] + %w[
     Changelog.md


### PR DESCRIPTION
In order to pass tests on Windows CI, drop the Ruby 2.3 target, which is not capable of connecting to https to get gems from RubyGems.org.

This updates the CI config and the linting configuration.