### PR TITLE
docs: Add CI status badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,7 @@
 # Rainbow
 
 [![Gem Version](https://badge.fury.io/rb/rainbow.svg)](https://rubygems.org/gems/rainbow)
+[![CI](https://github.com/sickill/rainbow/actions/workflows/ci.yml/badge.svg)](https://github.com/sickill/rainbow/actions/workflows/ci.yml)
 [![Code Climate](https://codeclimate.com/github/sickill/rainbow.svg)](https://codeclimate.com/github/sickill/rainbow)
 [![Coverage Status](https://coveralls.io/repos/sickill/rainbow/badge.svg)](https://coveralls.io/r/sickill/rainbow)
 


### PR DESCRIPTION
This PR adds the CI status badge.
![ss](https://user-images.githubusercontent.com/32959831/149308064-ceb1ab9e-de25-400c-9862-590e3ee032da.png)
