### PR TITLE
Add two styles `underline2x` and `overline`

### DIFF
--- a/lib/rainbow/null_presenter.rb
+++ b/lib/rainbow/null_presenter.rb
@@ -46,6 +46,14 @@ module Rainbow
       self
     end
 
+    def underline2x
+      self
+    end
+
+    def overline
+      self
+    end
+
     def black
       self
     end

--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -15,7 +15,9 @@ module Rainbow
       blink: 5,
       inverse: 7,
       hide: 8,
-      cross_out: 9
+      cross_out: 9,
+      underline2x: 21,
+      overline: 53
     }.freeze
 
     # Sets color of this text.
@@ -88,6 +90,14 @@ module Rainbow
     end
 
     alias strike cross_out
+
+    def underline2x
+      wrap_with_sgr(TERM_EFFECTS[:underline2x])
+    end
+
+    def overline
+      wrap_with_sgr(TERM_EFFECTS[:overline])
+    end
 
     def black
       color(:black)

--- a/spec/unit/null_presenter_spec.rb
+++ b/spec/unit/null_presenter_spec.rb
@@ -117,6 +117,18 @@ module Rainbow
       it_behaves_like "rainbow null string method"
     end
 
+    describe "#underline2x" do
+      subject { presenter.underline2x }
+
+      it_behaves_like "rainbow null string method"
+    end
+
+    describe "#overline" do
+      subject { presenter.overline }
+
+      it_behaves_like "rainbow null string method"
+    end
+
     it_behaves_like "presenter with shortcut color methods"
 
     describe "#method_missing" do

--- a/spec/unit/presenter_spec.rb
+++ b/spec/unit/presenter_spec.rb
@@ -216,6 +216,28 @@ module Rainbow
       end
     end
 
+    describe '#underline2x' do
+      subject { presenter.underline2x }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 21 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [21])
+      end
+    end
+
+    describe '#overline' do
+      subject { presenter.overline }
+
+      it_behaves_like "rainbow string method"
+
+      it 'wraps with 53 code' do
+        subject
+        expect(StringUtils).to have_received(:wrap_with_sgr).with('hello', [53])
+      end
+    end
+
     it_behaves_like "presenter with shortcut color methods"
   end
 end


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters

- I choose the word `overline` rather than `overlined` because our API is `underline` rather than `underlined`.
- I choose the word `underline2x` rather than `doublely_overlined` because it's complicated, and we can switch between `underline` and `underline2x` easily.

This is the screenshot on Windows Terminal:
<img width="471" alt="image" src="https://github.com/sickill/rainbow/assets/63459097/a5294796-12e9-4ea6-b8ae-313f299755d7">

