### PR TITLE
CI: Configure bundler: latest in setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby, truffleruby]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, 4.0, jruby, truffleruby]
         exclude:
           - { os: windows-latest, ruby: truffleruby }
     env:
       JRUBY_OPTS: '--debug'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          # the latest compatible Bundler version is installed (Bundler 2 on Ruby >= 2.3, Bundler 1 on Ruby < 2.3)
+          bundler: latest
       - name: Run test with Coveralls
         run: bundle exec rake
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.ruby == '3.3' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.ruby == '4.0' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: Run test
         run: bundle exec rake
-        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.ruby == '3.3') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, 4.0, jruby, truffleruby]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, '4.0', jruby, truffleruby]
         exclude:
           - { os: windows-latest, ruby: truffleruby }
     env:
@@ -23,8 +23,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          # the latest compatible Bundler version is installed (Bundler 2 on Ruby >= 2.3, Bundler 1 on Ruby < 2.3)
-          bundler: latest
       - name: Run test with Coveralls
         run: bundle exec rake
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.ruby == '4.0' }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "ostruct" # Used by coveralls (not part of the default gems since Ruby 4.0).
 gem 'rake'
 
 group :test do

--- a/rainbow.gemspec
+++ b/rainbow.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'Changelog.md', 'README.markdown', 'LICENSE']
   spec.require_paths = ["lib"]
-  spec.add_development_dependency "bundler", [">= 1.3", "< 3"]
+  spec.add_development_dependency "bundler"
 end


### PR DESCRIPTION
This PR tries to get to green, by using a Bundler version suiting each build target.

- Extend build matrix with Ruby 4.0. (Think about whether we are ever going to reduce the build matrix.)